### PR TITLE
Color conversion

### DIFF
--- a/parser/unit_test.py
+++ b/parser/unit_test.py
@@ -144,7 +144,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -262,7 +262,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -299,7 +299,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -339,7 +339,7 @@ expected = {
                                 'color_model': 'rgb',
                                 'color':
                                     {
-                                        'R': 289.0,  # should be 255
+                                        'R': 255.0,
                                         'G': 0.0,
                                         'B': 0.0,
                                         'is_null': False,
@@ -355,7 +355,7 @@ expected = {
                                     'color':
                                         {
                                             'R': 0.0,
-                                            'G': 257,  # should be 255
+                                            'G': 255,
                                             'B': 0,
                                             'is_null': False,
                                             'dither': True
@@ -371,7 +371,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -408,7 +408,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -445,7 +445,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -482,7 +482,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -512,8 +512,8 @@ expected = {
                             'color':
                                 {
                                     'R': 0.0,
-                                    'G': 134.0,  # should be 112
-                                    'B': 287.0,  # should be 255
+                                    'G': 112.0,
+                                    'B': 255.0,
                                     'is_null': False,
                                     'dither': False
                                 },
@@ -548,7 +548,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -562,8 +562,8 @@ expected = {
                         'outline_color_model': 'rgb',
                         'outline_color':
                             {
-                                'R': 249.0,  # should be 255
-                                'G': 256.0,  # should be 255
+                                'R': 255.0,
+                                'G': 255.0,
                                 'B': 0.0,
                                 'is_null': False,
                                 'dither': True
@@ -578,8 +578,8 @@ expected = {
                             'color':
                                 {
                                     'R': 0.0,
-                                    'G': 134.0,  # should be 112
-                                    'B': 287.0,  # should be 255
+                                    'G': 112.0,
+                                    'B': 255.0,
                                     'is_null': False,
                                     'dither': False
                                 },
@@ -592,7 +592,7 @@ expected = {
                             'outline_color':
                                 {
                                     'R': 0.0,
-                                    'G': 257.0,  # should be 255
+                                    'G': 255.0,
                                     'B': 0.0,
                                     'is_null': False,
                                     'dither': True
@@ -614,7 +614,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -651,7 +651,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -688,7 +688,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -725,7 +725,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -762,7 +762,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -799,7 +799,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -842,9 +842,9 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 245.0,  # should be 232
-                                'G': 200.0,  # should be 190
-                                'B': 264.0,  # should be 255
+                                'R': 232.0,
+                                'G': 190.0,
+                                'B': 255.0,
                                 'is_null': False,
                                 'dither': False
                             },
@@ -1176,9 +1176,9 @@ expected = {
                             'line_type': 'solid',
                             'color':
                                 {
-                                    'R': 243.0,  # should be 240
-                                    'G': 243,  # should be 240
-                                    'B': 243,  # should be 240
+                                    'R': 240.0,
+                                    'G': 240.0,
+                                    'B': 240.0,
                                     'is_null': True,
                                     'dither': True
                                 }
@@ -1196,7 +1196,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -1215,8 +1215,8 @@ expected = {
                                     'color':
                                         {
                                             'R': 0.0,
-                                            'G': 257.0,  # should be 255
-                                            'B': 0,
+                                            'G': 255.0,
+                                            'B': 0.0,
                                             'is_null': False,
                                             'dither': True
                                         }
@@ -1236,7 +1236,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -1255,7 +1255,7 @@ expected = {
                                     'color':
                                         {
                                             'R': 0.0,
-                                            'G': 257.0,  # should be 255
+                                            'G': 255.0,
                                             'B': 0,
                                             'is_null': False,
                                             'dither': True
@@ -1272,7 +1272,7 @@ expected = {
                                             {
                                                 'R': 0.0,
                                                 'G': 0.0,
-                                                'B': 303.0,  # should be 255
+                                                'B': 255.0,
                                                 'is_null': False,
                                                 'dither': True
                                             }
@@ -1292,7 +1292,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -1311,7 +1311,7 @@ expected = {
                                     'color':
                                         {
                                             'R': 0.0,
-                                            'G': 257.0,  # should be 255
+                                            'G': 255.0,
                                             'B': 0,
                                             'is_null': False,
                                             'dither': True
@@ -1328,7 +1328,7 @@ expected = {
                                             {
                                                 'R': 0.0,
                                                 'G': 0.0,
-                                                'B': 303.0,  # should be 255
+                                                'B': 255.0,
                                                 'is_null': False,
                                                 'dither': True
                                             }
@@ -1344,7 +1344,7 @@ expected = {
                             'color':
                                 {
                                     'R': 0.0,
-                                    'G': 257.0,  # should be 255
+                                    'G': 255.0,
                                     'B': 0.0,
                                     'is_null': False,
                                     'dither': True
@@ -1361,9 +1361,9 @@ expected = {
                                         'line_type': 'solid',
                                         'color':
                                             {
-                                                'R': 129.0,  # should be 110
-                                                'G': 129.0,  # should be 110
-                                                'B': 129.0,  # should be 110
+                                                'R': 110.0,
+                                                'G': 110.0,
+                                                'B': 110.0,
                                                 'is_null': False,
                                                 'dither': True
                                             }
@@ -1377,7 +1377,7 @@ expected = {
                                             'line_type': 'dashed',
                                             'color':
                                                 {
-                                                    'R': 289.0,  # should be 255
+                                                    'R': 255.0,
                                                     'G': 0.0,
                                                     'B': 0.0,
                                                     'is_null': False,
@@ -1399,7 +1399,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0.0,
                                 'B': 0.0,
                                 'is_null': False,
@@ -1416,8 +1416,8 @@ expected = {
                                     'color':
                                         {
                                             'R': 0.0,
-                                            'G': 0,
-                                            'B': 303,  # should be 255
+                                            'G': 0.0,
+                                            'B': 255,
                                             'is_null': False,
                                             'dither': True
                                         },
@@ -1479,7 +1479,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1503,7 +1503,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1527,7 +1527,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1551,7 +1551,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1575,7 +1575,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1599,7 +1599,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1623,7 +1623,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1646,7 +1646,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1670,7 +1670,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1694,7 +1694,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1718,7 +1718,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1742,7 +1742,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1766,7 +1766,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1790,7 +1790,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1814,7 +1814,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1838,7 +1838,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1864,7 +1864,7 @@ expected = {
                         'line_type': 'dash dot dot',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1885,7 +1885,7 @@ expected = {
                         'line_type': 'dash dot',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1906,7 +1906,7 @@ expected = {
                         'line_type': 'dashed',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1927,7 +1927,7 @@ expected = {
                         'line_type': 'dotted',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1952,7 +1952,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -1973,7 +1973,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -2002,7 +2002,7 @@ expected = {
                         'line_type': 'null',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -2029,7 +2029,7 @@ expected = {
                         'line_type': 'solid',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -2048,7 +2048,7 @@ expected = {
                         'color_model': 'rgb',
                         'color':
                             {
-                                'R': 289.0,  # should be 255
+                                'R': 255.0,
                                 'G': 0,
                                 'B': 0,
                                 'is_null': False,
@@ -2072,7 +2072,7 @@ expected = {
                             'line_type': 'solid',
                             'color':
                                 {
-                                    'R': 289.0,  # should be 255
+                                    'R': 255.0,
                                     'G': 0,
                                     'B': 0,
                                     'is_null': False,
@@ -2088,9 +2088,9 @@ expected = {
                             'line_type': 'solid',
                             'color':
                                 {
-                                    'R': 129.0,  # should be 110
-                                    'G': 129.0,
-                                    'B': 129.0,
+                                    'R': 110.0,
+                                    'G': 110.0,
+                                    'B': 110.0,
                                     'is_null': False,
                                     'dither': True
                                 }
@@ -2110,7 +2110,7 @@ expected = {
                             'line_type': 'dotted',
                             'color':
                                 {
-                                    'R': 289.0,  # should be 255
+                                    'R': 255.0,
                                     'G': 0,
                                     'B': 0,
                                     'is_null': False,
@@ -2126,9 +2126,9 @@ expected = {
                             'line_type': 'dash dot',
                             'color':
                                 {
-                                    'R': 129.0,  # should be 110
-                                    'G': 129.0,
-                                    'B': 129.0,
+                                    'R': 110.0,
+                                    'G': 110.0,
+                                    'B': 110.0,
                                     'is_null': False,
                                     'dither': True
                                 }
@@ -2143,7 +2143,7 @@ expected = {
                             'color':
                                 {
                                     'R': 0.0,
-                                    'G': 257.0,  # should be 255
+                                    'G': 255.0,
                                     'B': 0.0,
                                     'is_null': False,
                                     'dither': True

--- a/parser/unit_test_color_parser.py
+++ b/parser/unit_test_color_parser.py
@@ -1,0 +1,55 @@
+import unittest
+from color_parser import (cielab_to_xyz, xyz_to_rgb, cielab_to_rgb)
+
+class TestColorParser(unittest.TestCase):
+    """The LAB values are obtained from the color selector in ArcMap"""
+
+    def test_lab_to_rgb_red(self):
+        r, g, b = cielab_to_rgb(
+            56.547017615341,
+            76.8994334713463,
+            68.1034442713808)
+
+        self.assertEqual(255.0, r)
+        self.assertEqual(0.0, g)
+        self.assertEqual(0.0, b)
+
+    def test_lab_to_rgb_green(self):
+        r, g, b = cielab_to_rgb(
+            85.6070742290004,
+            -91.4861929759672,
+            73.9622026853808)
+
+        self.assertEqual(0.0, r)
+        self.assertEqual(255.0, g)
+        self.assertEqual(0.0, b)
+
+    def test_lab_to_rgb_blue(self):
+        r, g, b = cielab_to_rgb(
+            34.6689828323685,
+            71.1255602213487,
+            -101.887893082443)
+
+        self.assertEqual(0.0, r)
+        self.assertEqual(0.0, g)
+        self.assertEqual(255.0, b)
+
+    def test_lab_to_rgb_grey(self):
+        r, g, b = cielab_to_rgb(
+            60.3512433104593,
+            0.0,
+            0.0)
+
+        self.assertEqual(127.0, r)
+        self.assertEqual(127.0, g)
+        self.assertEqual(127.0, b)
+
+    def test_lab_to_rgb_random_pink(self):
+        r, g, b = cielab_to_rgb(
+            61.3159233343074,
+            87.5007924739545,
+            -47.2983051839587)
+
+        self.assertEqual(242.0, r)
+        self.assertEqual(13.0, g)
+        self.assertEqual(232.0, b)

--- a/specs.md
+++ b/specs.md
@@ -34,22 +34,9 @@ This corresponds to
 - A: 76.899433
 - B: 68.103444
 
-According to http://edndoc.esri.com/arcobjects/9.2/ComponentHelp/esriDisplay/IColor_GetCIELAB.htm, ESRI use ranges of 0-100 for L, -120-120 for A and B
+It seems that ESRI utilises Apple RGB Model as RGB Model with Whitepoint D65 and Gamma 1.8. Using these settings, we get RGB values very similar to those showed into ESRI products. Only for RGB values very close to zero, we have sometimes small differences, probably due to some approximation.
 
-Scaling these values to the standard 0-100,-128-128 ranges gives us:
-
-- L: 56.547018
-- A: 82.0260619
-- B: 72.6436736
-
-Unfortunately conversion of these values back to RGB results in R: 255, G: 19, B: 0.
-At least, according to http://colormine.org/convert/rgb-to-lab we should expect:
-
-- C: 53.23288178584245
-- I: 80.10930952982204
-- E: 67.22006831026425
-
-For #ff0000. It's possible that ESRI utilise a different whitepoint in their conversion of CIELAB -> RGB. 
+The conversion rules and value can be found on [Bruce Lindbloom site](http://www.brucelindbloom.com/)
 
 Immediately following the 8-byte color components, the next byte indicates whether the color has the "use windows dithering" option enabled (!) Not sure who really cares about this option anymore, but the following values are possible for this byte:
 


### PR DESCRIPTION
Hi Nyall,
thanks for this project. It's really great.

I started to tinker with the color convesion and I found some good settings to convert ESRI LAB colors to RGB. It seems that ESRI utilises Apple RGB as RGB Model with whitepoint D65 and Gamma 1.8. Using these settings, I get RGB values very similar to those showed into ESRI products. Only for RGB values very close to zero, I have sometimes small differences, probably due to approximations.
Changes:
- I modified the algorithm into `color_parser` module
- I changed the fake RGB codes into your unit tests to the correct ones (all passed)
- I added a few unit tests for the conversion algorithm
- I updated the `specs.md` documentation